### PR TITLE
Es Client変更

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,19 +24,17 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
     </dependency>
-
+<!--
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
     </dependency>
-
-    <!--
-        <dependency>
-          <groupId>org.elasticsearch.client</groupId>
-          <artifactId>elasticsearch-rest-high-level-client</artifactId>
-          <version>7.6.1</version>
-        </dependency>
-    -->
+-->
+    <dependency>
+      <groupId>org.elasticsearch.client</groupId>
+      <artifactId>elasticsearch-rest-high-level-client</artifactId>
+      <version>7.6.1</version>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -57,12 +55,6 @@
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jetbrains</groupId>
-      <artifactId>annotations</artifactId>
-      <version>RELEASE</version>
-      <scope>compile</scope>
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
spring-boot-starter-data-elasticsearchを利用して、複数のEs ClientをBean定義すると下記エラーが出るので、elasticsearch-rest-high-level-clientに変更する。


```
2021-01-07 00:00:50.748  INFO 3120 --- [           main] ConditionEvaluationReportLoggingListener : 

Error starting ApplicationContext. To display the conditions report re-run your application with 'debug' enabled.
2021-01-07 00:00:50.763 ERROR 3120 --- [           main] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

Parameter 0 of method elasticsearchTemplate in org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataConfiguration$RestClientConfiguration required a single bean, but 2 were found:
	- EsClient: defined by method 'getElasticsearchClient' in class path resource [com/springboot/sandbox/es/springbootsandboxes/elasticsearch/EsClient.class]
	- EsClientSub: defined by method 'getElasticsearchClientSub' in class path resource [com/springboot/sandbox/es/springbootsandboxes/elasticsearch/EsClientSub.class]


Action:

Consider marking one of the beans as @Primary, updating the consumer to accept multiple beans, or using @Qualifier to identify the bean that should be consumed


Process finished with exit code 1
```
